### PR TITLE
Use logger instead of print in experiments

### DIFF
--- a/examples/gym/train_ddpg_gym.py
+++ b/examples/gym/train_ddpg_gym.py
@@ -10,6 +10,7 @@ import sys
 import chainer
 from chainer import optimizers
 import gym
+gym.undo_logger_setup()
 from gym import spaces
 import gym.wrappers
 import numpy as np
@@ -148,7 +149,6 @@ def main():
                  soft_update_tau=args.soft_update_tau,
                  n_times_update=args.n_update_times,
                  phi=phi, gpu=args.gpu, minibatch_size=args.minibatch_size)
-    agent.logger.setLevel(logging.DEBUG)
 
     if len(args.load) > 0:
         agent.load(args.load)

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -152,7 +152,6 @@ def main():
                 target_update_method=args.target_update_method,
                 soft_update_tau=args.soft_update_tau,
                 episodic_update=args.episodic_replay, episodic_update_len=16)
-    agent.logger.setLevel(logging.DEBUG)
 
     if args.load:
         agent.load(args.load)

--- a/examples/gym/train_pcl_gym.py
+++ b/examples/gym/train_pcl_gym.py
@@ -20,6 +20,7 @@ import argparse
 
 import chainer
 import gym
+gym.undo_logger_setup()
 import gym.wrappers
 import numpy as np
 
@@ -72,7 +73,7 @@ def main():
                         dest='backprop_future_values')
     args = parser.parse_args()
 
-    logging.getLogger().setLevel(args.logger_level)
+    logging.basicConfig(level=args.logger_level)
 
     if args.seed is not None:
         misc.set_random_seed(args.seed)

--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -462,6 +462,12 @@
     }
    ],
    "source": [
+    "# Set up the logger to print info messages for understandability.\n",
+    "import logging\n",
+    "import sys\n",
+    "gym.undo_logger_setup()  # Turn off gym's default logger settings\n",
+    "logging.basicConfig(level=logging.INFO, stream=sys.stdout, format='')\n",
+    "\n",
     "chainerrl.experiments.train_agent_with_evaluation(\n",
     "    agent, env,\n",
     "    steps=2000,           # Train the agent for 2000 steps\n",


### PR DESCRIPTION
Resolves #32 

- Replace `print` sentences in `chainerrl.experiments` module with `logger.info` so that you can configure it.
- Modify the quickstart notebook to print info messages into stdout as before.
- Additionally, use `gym.undo_logger_setup` in other examples for consistency and clearness.