### PR TITLE
Use hook functions

### DIFF
--- a/chainerrl/experiments/__init__.py
+++ b/chainerrl/experiments/__init__.py
@@ -1,5 +1,8 @@
 from chainerrl.experiments.evaluator import eval_performance  # NOQA
 
+from chainerrl.experiments.hooks import LinearInterpolationHook  # NOQA
+from chainerrl.experiments.hooks import StepHook  # NOQA
+
 from chainerrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from chainerrl.experiments.prepare_output_dir import prepare_output_dir  # NOQA
 

--- a/chainerrl/experiments/hooks.py
+++ b/chainerrl/experiments/hooks.py
@@ -23,6 +23,13 @@ class StepHook(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def __call__(self, env, agent, step):
+        """Call the hook.
+
+        Args:
+            env: Environment.
+            agent: Agent.
+            step: Current timestep.
+        """
         raise NotImplementedError
 
 
@@ -30,12 +37,14 @@ class LinearInterpolationHook(StepHook):
     """Hook that will set a linearly interpolated value.
 
     You can use this hook to decay the learning rate by using a setter function
-    like:
+    as follows:
 
     .. code-block:: python
 
         def lr_setter(env, agent, value):
             agent.optimizer.lr = value
+
+        hook = LinearInterpolationHook(10 ** 6, 1e-3, 0, lr_setter)
 
 
     Args:

--- a/chainerrl/experiments/hooks.py
+++ b/chainerrl/experiments/hooks.py
@@ -14,7 +14,12 @@ import numpy as np
 
 
 class StepHook(with_metaclass(ABCMeta, object)):
-    """Hook function that will be called in training."""
+    """Hook function that will be called in training.
+
+    This class is for clarifying the interface required for Hook functions.
+    You don't need to inherit this class to define your own hooks. Any callable
+    that accepts (env, agent, step) as arguments can be used as a hook.
+    """
 
     @abstractmethod
     def __call__(self, env, agent, step):
@@ -23,6 +28,15 @@ class StepHook(with_metaclass(ABCMeta, object)):
 
 class LinearInterpolationHook(StepHook):
     """Hook that will set a linearly interpolated value.
+
+    You can use this hook to decay the learning rate by using a setter function
+    like:
+
+    .. code-block:: python
+
+        def lr_setter(env, agent, value):
+            agent.optimizer.lr = value
+
 
     Args:
         total_steps (int): Number of total steps.

--- a/chainerrl/experiments/hooks.py
+++ b/chainerrl/experiments/hooks.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+from future.utils import with_metaclass
+import numpy as np
+
+
+class StepHook(with_metaclass(ABCMeta, object)):
+    """Hook function that will be called in training."""
+
+    @abstractmethod
+    def __call__(self, env, agent, step):
+        raise NotImplementedError
+
+
+class LinearInterpolationHook(StepHook):
+    """Hook that will set a linearly interpolated value.
+
+    Args:
+        total_steps (int): Number of total steps.
+        start_value (float): Start value.
+        stop_value (float): Stop value.
+        setter (callable): (env, agent, value) -> None
+    """
+
+    def __init__(self, total_steps, start_value, stop_value, setter):
+        self.total_steps = total_steps
+        self.start_value = start_value
+        self.stop_value = stop_value
+        self.setter = setter
+
+    def __call__(self, env, agent, step):
+        value = np.interp(step,
+                          [1, self.total_steps],
+                          [self.start_value, self.stop_value])
+        self.setter(env, agent, value)

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -29,7 +29,7 @@ def ask_and_save_agent_replay_buffer(agent, t, outdir, suffix=''):
 
 def train_agent(agent, env, steps, outdir, max_episode_len=None,
                 step_offset=0, evaluator=None, successful_score=None,
-                logger=None):
+                step_hooks=[], logger=None):
 
     logger = logger or logging.getLogger(__name__)
 
@@ -55,6 +55,9 @@ def train_agent(agent, env, steps, outdir, max_episode_len=None,
             t += 1
             episode_r += r
             episode_len += 1
+
+            for hook in step_hooks:
+                hook(env, agent, t)
 
             if done or episode_len == max_episode_len or t == steps:
                 agent.stop_episode_and_train(obs, r, done=done)
@@ -90,7 +93,7 @@ def train_agent_with_evaluation(
         agent, env, steps, eval_n_runs, eval_interval,
         outdir, max_episode_len=None, step_offset=0, eval_explorer=None,
         eval_max_episode_len=None, eval_env=None, successful_score=None,
-        render=False, logger=None):
+        render=False, step_hooks=[], logger=None):
     """Run a DQN-like agent.
 
     Args:
@@ -106,6 +109,9 @@ def train_agent_with_evaluation(
       eval_env: Environment used for evaluation.
       successful_score (float): Finish training if the mean score is greater
           or equal to this value if not None
+      step_hooks (list): List of callable objects that accepts
+          (env, agent, step) as arguments. They are called every step.
+          See chainerrl.experiments.hooks.
     """
 
     logger = logger or logging.getLogger(__name__)
@@ -128,6 +134,10 @@ def train_agent_with_evaluation(
                           logger=logger)
 
     train_agent(
-        agent, env, steps, outdir, max_episode_len=max_episode_len,
-        step_offset=step_offset, evaluator=evaluator,
-        successful_score=successful_score, logger=logger)
+        agent, env, steps, outdir,
+        max_episode_len=max_episode_len,
+        step_offset=step_offset,
+        evaluator=evaluator,
+        successful_score=successful_score,
+        step_hooks=step_hooks,
+        logger=logger)

--- a/chainerrl/experiments/train_agent.py
+++ b/chainerrl/experiments/train_agent.py
@@ -93,25 +93,26 @@ def train_agent_with_evaluation(
         agent, env, steps, eval_n_runs, eval_interval,
         outdir, max_episode_len=None, step_offset=0, eval_explorer=None,
         eval_max_episode_len=None, eval_env=None, successful_score=None,
-        render=False, step_hooks=[], logger=None):
-    """Run a DQN-like agent.
+        step_hooks=[], logger=None):
+    """Train an agent while regularly evaluating it.
 
     Args:
-      agent: Agent.
-      env: Environment.
-      steps (int): Number of total time steps for training.
-      eval_n_runs (int): Number of runs for each time of evaluation.
-      eval_interval (int): Interval of evaluation.
-      outdir (str): Path to the directory to output things.
-      max_episode_len (int): Maximum episode length.
-      step_offset (int): Time step from which training starts.
-      eval_explorer: Explorer used for evaluation.
-      eval_env: Environment used for evaluation.
-      successful_score (float): Finish training if the mean score is greater
-          or equal to this value if not None
-      step_hooks (list): List of callable objects that accepts
-          (env, agent, step) as arguments. They are called every step.
-          See chainerrl.experiments.hooks.
+        agent: Agent to train.
+        env: Environment train the againt against.
+        steps (int): Number of total time steps for training.
+        eval_n_runs (int): Number of runs for each time of evaluation.
+        eval_interval (int): Interval of evaluation.
+        outdir (str): Path to the directory to output things.
+        max_episode_len (int): Maximum episode length.
+        step_offset (int): Time step from which training starts.
+        eval_explorer: Explorer used for evaluation.
+        eval_env: Environment used for evaluation.
+        successful_score (float): Finish training if the mean score is greater
+            or equal to this value if not None
+        step_hooks (list): List of callable objects that accepts
+            (env, agent, step) as arguments. They are called every step.
+            See chainerrl.experiments.hooks.
+        logger (logging.Logger): Logger used in this function.
     """
 
     logger = logger or logging.getLogger(__name__)

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -124,27 +124,44 @@ def set_shared_objects(agent, shared_objects):
 
 
 def train_agent_async(outdir, processes, make_env,
-                      profile=False, steps=8 * 10 ** 7, eval_interval=10 ** 6,
-                      eval_n_runs=10, gamma=0.99, max_episode_len=None,
-                      step_offset=0, successful_score=None,
+                      profile=False,
+                      steps=8 * 10 ** 7,
+                      eval_interval=10 ** 6,
+                      eval_n_runs=10,
+                      max_episode_len=None,
+                      step_offset=0,
+                      successful_score=None,
                       eval_explorer=None,
-                      agent=None, make_agent=None,
+                      agent=None,
+                      make_agent=None,
                       global_step_hooks=[],
                       logger=None):
-    """Train agent asynchronously.
+    """Train agent asynchronously using multiprocessing.
 
-    One of agent and make_agent must be specified.
+    Either `agent` or `make_agent` must be specified.
 
     Args:
-      agent (Agent): Agent to train
-      make_agent (callable): (process_idx) -> Agent
-      processes (int): Number of processes.
-      make_env (callable): (process_idx, test) -> env
-      model_opt (callable): () -> (models, optimizers)
-      profile (bool): Profile if set True
-      global_step_hooks (list): List of StepHook objects called every global
-          step.
-      steps (int): Number of global time steps for training
+        outdir (str): Path to the directory to output things.
+        processes (int): Number of processes.
+        make_env (callable): (process_idx, test) -> Environment.
+        profile (bool): Profile if set True.
+        steps (int): Number of global time steps for training.
+        eval_interval (int): Interval of evaluation.
+        eval_n_runs (int): Number of runs for each time of evaluation.
+        max_episode_len (int): Maximum episode length.
+        step_offset (int): Time step from which training starts.
+        successful_score (float): Finish training if the mean score is greater
+            or equal to this value if not None
+        eval_explorer: Explorer used for evaluation.
+        agent (Agent): Agent to train.
+        make_agent (callable): (process_idx) -> Agent
+        global_step_hooks (list): List of callable objects that accepts
+            (env, agent, step) as arguments. They are called every global
+            step. See chainerrl.experiments.hooks.
+        logger (logging.Logger): Logger used in this function.
+
+    Returns:
+        Trained agent.
     """
 
     logger = logger or logging.getLogger(__name__)

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -2,6 +2,17 @@
 Experiments
 ===========
 
+Training and evaluation
+=======================
+
 .. autofunction:: chainerrl.experiments.train_agent_async
 
 .. autofunction:: chainerrl.experiments.train_agent_with_evaluation
+
+Training hooks
+==============
+
+.. autoclass:: chainerrl.experiments.StepHook
+   :members:
+
+.. autoclass:: chainerrl.experiments.LinearInterpolationHook

--- a/examples/ale/train_a3c_ale.py
+++ b/examples/ale/train_a3c_ale.py
@@ -126,6 +126,14 @@ def main():
             args.eval_n_runs, eval_stats['mean'], eval_stats['median'],
             eval_stats['stdev']))
     else:
+
+        # Linearly decay the learning rate to zero
+        def lr_setter(env, agent, value):
+            agent.optimizer.lr = value
+
+        lr_decay_hook = experiments.LinearInterpolationHook(
+            args.steps, args.lr, 0, lr_setter)
+
         experiments.train_agent_async(
             agent=agent,
             outdir=args.outdir,
@@ -135,7 +143,8 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len)
+            max_episode_len=args.max_episode_len,
+            global_step_hooks=[lr_decay_hook])
 
 
 if __name__ == '__main__':

--- a/examples/ale/train_acer_ale.py
+++ b/examples/ale/train_acer_ale.py
@@ -121,6 +121,14 @@ def main():
             args.eval_n_runs, eval_stats['mean'], eval_stats['median'],
             eval_stats['stdev']))
     else:
+
+        # Linearly decay the learning rate to zero
+        def lr_setter(env, agent, value):
+            agent.optimizer.lr = value
+
+        lr_decay_hook = experiments.LinearInterpolationHook(
+            args.steps, args.lr, 0, lr_setter)
+
         experiments.train_agent_async(
             agent=agent,
             outdir=args.outdir,
@@ -130,7 +138,8 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            max_episode_len=args.max_episode_len)
+            max_episode_len=args.max_episode_len,
+            global_step_hooks=[lr_decay_hook])
 
 
 if __name__ == '__main__':

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -106,6 +106,14 @@ def main():
             eval_stats['stdev']))
     else:
         explorer = explorers.ConstantEpsilonGreedy(0.05, action_space.sample)
+
+        # Linearly decay the learning rate to zero
+        def lr_setter(env, agent, value):
+            agent.optimizer.lr = value
+
+        lr_decay_hook = experiments.LinearInterpolationHook(
+            args.steps, args.lr, 0, lr_setter)
+
         experiments.train_agent_async(
             outdir=args.outdir,
             processes=args.processes,
@@ -115,7 +123,8 @@ def main():
             steps=args.steps,
             eval_n_runs=args.eval_n_runs,
             eval_interval=args.eval_interval,
-            eval_explorer=explorer)
+            eval_explorer=explorer,
+            global_step_hooks=[lr_decay_hook])
 
 if __name__ == '__main__':
     main()

--- a/examples/ale/train_nsq_ale.py
+++ b/examples/ale/train_nsq_ale.py
@@ -37,6 +37,7 @@ def main():
     parser.add_argument('processes', type=int)
     parser.add_argument('rom', type=str)
     parser.add_argument('--seed', type=int, default=None)
+    parser.add_argument('--lr', type=float, default=7e-4)
     parser.add_argument('--steps', type=int, default=8 * 10 ** 7)
     parser.add_argument('--use-sdl', action='store_true', default=False)
     parser.add_argument('--final-exploration-frames',
@@ -72,7 +73,7 @@ def main():
         links.NIPSDQNHead(),
         L.Linear(256, action_space.n),
         DiscreteActionValue)
-    opt = rmsprop_async.RMSpropAsync(lr=7e-4, eps=1e-1, alpha=0.99)
+    opt = rmsprop_async.RMSpropAsync(lr=args.lr, eps=1e-1, alpha=0.99)
     opt.setup(q_func)
 
     # Make process-specific agents to diversify exploration

--- a/tests/experiments_tests/test_hooks.py
+++ b/tests/experiments_tests/test_hooks.py
@@ -1,0 +1,34 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+import unittest
+
+import numpy as np
+
+import chainerrl
+
+
+class TestLinearInterpolationHook(unittest.TestCase):
+
+    def test_call(self):
+
+        buf = []
+
+        def setter(env, agent, value):
+            buf.append(value)
+
+        hook = chainerrl.experiments.LinearInterpolationHook(
+            total_steps=10,
+            start_value=0.1,
+            stop_value=1.0,
+            setter=setter)
+
+        for step in range(1, 10 + 1):
+            hook(env=None, agent=None, step=step)
+
+        np.testing.assert_allclose(
+            buf, np.arange(1, 10 + 1, dtype=np.float32) / 10)

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import *  # NOQA
+from future import standard_library
+standard_library.install_aliases()
+import tempfile
+import unittest
+
+import mock
+
+import chainerrl
+
+
+class TestTrainAgent(unittest.TestCase):
+
+    def test(self):
+
+        outdir = tempfile.mkdtemp()
+
+        agent = mock.Mock()
+        env = mock.Mock()
+        # Reaches the terminal state after five actions
+        env.reset.side_effect = [('state', 0)]
+        env.step.side_effect = [
+            (('state', 1), 0, False, {}),
+            (('state', 2), 0, False, {}),
+            (('state', 3), -0.5, False, {}),
+            (('state', 4), 0, False, {}),
+            (('state', 5), 1, True, {}),
+        ]
+        hook = mock.Mock()
+
+        chainerrl.experiments.train_agent(
+            agent=agent,
+            env=env,
+            steps=5,
+            outdir=outdir,
+            step_hooks=[hook])
+
+        self.assertEqual(agent.act_and_train.call_count, 5)
+        self.assertEqual(agent.stop_episode_and_train.call_count, 1)
+
+        self.assertEqual(env.reset.call_count, 1)
+        self.assertEqual(env.step.call_count, 5)
+
+        self.assertEqual(hook.call_count, 5)
+        # A hook receives (env, agent, step)
+        for i, call in enumerate(hook.call_args_list):
+            args, kwargs = call
+            self.assertEqual(args[0], env)
+            self.assertEqual(args[1], agent)
+            # step starts with 1
+            self.assertEqual(args[2], i + 1)


### PR DESCRIPTION
This PR add `StepHook` interface to customize training loops, e.g. decaying or increasing some parameters. Learning rate decaying in `chainerrl.experiments.train_agent_async` is now implemented using a hook.

Resolves #84