### PR TITLE
Stabilize agent tests

### DIFF
--- a/chainerrl/distribution.py
+++ b/chainerrl/distribution.py
@@ -177,9 +177,12 @@ class SoftmaxDistribution(CategoricalDistribution):
             distribution.
     """
 
-    def __init__(self, logits, beta=1.0):
+    def __init__(self, logits, beta=1.0, min_prob=0.0):
         self.logits = logits
         self.beta = 1.0
+        self.min_prob = min_prob
+        self.n = logits.shape[1]
+        assert self.min_prob * self.n <= 1.0
 
     @property
     def params(self):
@@ -188,12 +191,19 @@ class SoftmaxDistribution(CategoricalDistribution):
     @cached_property
     def all_prob(self):
         with chainer.force_backprop_mode():
-            return F.softmax(self.beta * self.logits)
+            if self.min_prob > 0:
+                return (F.softmax(self.beta * self.logits)
+                        * (1 - self.min_prob * self.n)) + self.min_prob
+            else:
+                return F.softmax(self.beta * self.logits)
 
     @cached_property
     def all_log_prob(self):
         with chainer.force_backprop_mode():
-            return F.log_softmax(self.beta * self.logits)
+            if self.min_prob > 0:
+                return F.log(self.all_prob)
+            else:
+                return F.log_softmax(self.beta * self.logits)
 
     def copy(self):
         return SoftmaxDistribution(_unwrap_variable(self.logits).copy(),

--- a/chainerrl/policies/softmax_policy.py
+++ b/chainerrl/policies/softmax_policy.py
@@ -27,13 +27,15 @@ class SoftmaxPolicy(chainer.Chain, Policy):
             Parameter of Boltzmann distributions.
     """
 
-    def __init__(self, model, beta=1.0):
+    def __init__(self, model, beta=1.0, min_prob=0.0):
         self.beta = beta
+        self.min_prob = min_prob
         super().__init__(model=model)
 
     def __call__(self, x, test=False):
         h = self.model(x, test=test)
-        return distribution.SoftmaxDistribution(h, beta=self.beta)
+        return distribution.SoftmaxDistribution(
+            h, beta=self.beta, min_prob=self.min_prob)
 
 
 class FCSoftmaxPolicy(SoftmaxPolicy):
@@ -42,7 +44,8 @@ class FCSoftmaxPolicy(SoftmaxPolicy):
     def __init__(self, n_input_channels, n_actions,
                  n_hidden_layers=0, n_hidden_channels=None,
                  beta=1.0, nonlinearity=F.relu,
-                 last_wscale=1.0):
+                 last_wscale=1.0,
+                 min_prob=0.0):
         self.n_input_channels = n_input_channels
         self.n_actions = n_actions
         self.n_hidden_layers = n_hidden_layers
@@ -55,4 +58,5 @@ class FCSoftmaxPolicy(SoftmaxPolicy):
                       (n_hidden_channels,) * n_hidden_layers,
                       nonlinearity=nonlinearity,
                       last_wscale=last_wscale),
-            beta=self.beta)
+            beta=self.beta,
+            min_prob=min_prob)

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -85,7 +85,8 @@ class TestA3C(unittest.TestCase):
                     pi=policies.FCSoftmaxPolicy(
                         n_hidden_channels, action_space.n,
                         n_hidden_channels=n_hidden_channels,
-                        n_hidden_layers=2),
+                        n_hidden_layers=2,
+                        min_prob=1e-1),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
                         n_hidden_channels=n_hidden_channels,
@@ -100,7 +101,8 @@ class TestA3C(unittest.TestCase):
                         n_hidden_layers=2,
                         bound_mean=True,
                         min_action=action_space.low,
-                        max_action=action_space.high),
+                        max_action=action_space.high,
+                        min_var=0.1),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
                         n_hidden_channels=n_hidden_channels,
@@ -112,7 +114,8 @@ class TestA3C(unittest.TestCase):
                     pi=policies.FCSoftmaxPolicy(
                         obs_space.low.size, action_space.n,
                         n_hidden_channels=n_hidden_channels,
-                        n_hidden_layers=2),
+                        n_hidden_layers=2,
+                        min_prob=1e-1),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
                         n_hidden_channels=n_hidden_channels,
@@ -126,7 +129,8 @@ class TestA3C(unittest.TestCase):
                         n_hidden_layers=2,
                         bound_mean=True,
                         min_action=action_space.low,
-                        max_action=action_space.high),
+                        max_action=action_space.high,
+                        min_var=0.1),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
                         n_hidden_channels=n_hidden_channels,

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -383,7 +383,8 @@ class TestACER(unittest.TestCase):
                         n_hidden_channels, action_space.n,
                         n_hidden_channels=n_hidden_channels,
                         n_hidden_layers=n_hidden_layers,
-                        nonlinearity=nonlinearity),
+                        nonlinearity=nonlinearity,
+                        min_prob=1e-1),
                     q=q_function.FCStateQFunctionWithDiscreteAction(
                         n_hidden_channels, action_space.n,
                         n_hidden_channels=n_hidden_channels,
@@ -400,7 +401,8 @@ class TestACER(unittest.TestCase):
                         bound_mean=True,
                         min_action=action_space.low,
                         max_action=action_space.high,
-                        nonlinearity=nonlinearity),
+                        nonlinearity=nonlinearity,
+                        min_var=1e-1),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
                         n_hidden_channels=n_hidden_channels,
@@ -419,7 +421,8 @@ class TestACER(unittest.TestCase):
                         obs_space.low.size, action_space.n,
                         n_hidden_channels=n_hidden_channels,
                         n_hidden_layers=n_hidden_layers,
-                        nonlinearity=nonlinearity),
+                        nonlinearity=nonlinearity,
+                        min_prob=1e-1),
                     q=q_function.FCStateQFunctionWithDiscreteAction(
                         obs_space.low.size, action_space.n,
                         n_hidden_channels=n_hidden_channels,
@@ -435,7 +438,8 @@ class TestACER(unittest.TestCase):
                         bound_mean=True,
                         min_action=action_space.low,
                         max_action=action_space.high,
-                        nonlinearity=nonlinearity),
+                        nonlinearity=nonlinearity,
+                        min_var=1e-1),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
                         n_hidden_channels=n_hidden_channels,
@@ -447,11 +451,11 @@ class TestACER(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity),
                 )
-        eps = 1e-2
+        eps = 1e-8
         opt = rmsprop_async.RMSpropAsync(lr=1e-3, eps=eps, alpha=0.99)
         opt.setup(model)
         gamma = 0.5
-        beta = 1e-2
+        beta = 1e-5
         if self.n_times_replay == 0 and self.disable_online_update:
             # At least one of them must be enabled
             self.disable_online_update = False

--- a/tests/agents_tests/test_pcl.py
+++ b/tests/agents_tests/test_pcl.py
@@ -100,6 +100,7 @@ class TestPCL(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity,
                         last_wscale=1e-2,
+                        min_prob=1e-1,
                     ),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
@@ -121,7 +122,9 @@ class TestPCL(unittest.TestCase):
                         var_bias=1,
                         bound_mean=True,
                         min_action=action_space.low,
-                        max_action=action_space.high),
+                        max_action=action_space.high,
+                        min_var=1e-1,
+                    ),
                     v=v_function.FCVFunction(
                         n_hidden_channels,
                         n_hidden_channels=n_hidden_channels,
@@ -139,6 +142,7 @@ class TestPCL(unittest.TestCase):
                         n_hidden_layers=n_hidden_layers,
                         nonlinearity=nonlinearity,
                         last_wscale=1e-2,
+                        min_prob=1e-1,
                     ),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
@@ -159,7 +163,9 @@ class TestPCL(unittest.TestCase):
                         var_bias=1,
                         bound_mean=True,
                         min_action=action_space.low,
-                        max_action=action_space.high),
+                        max_action=action_space.high,
+                        min_var=1e-1,
+                    ),
                     v=v_function.FCVFunction(
                         obs_space.low.size,
                         n_hidden_channels=n_hidden_channels,

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -20,6 +20,8 @@ from chainerrl import distribution
     'batch_size': [1, 3],
     'n': [1, 2, 10],
     'wrap_by_variable': [True, False],
+    'beta': [1.0, 10.0],
+    'min_prob': [0.0, 0.01, 0.1],
 }))
 class TestSoftmaxDistribution(unittest.TestCase):
 
@@ -27,9 +29,14 @@ class TestSoftmaxDistribution(unittest.TestCase):
         self.logits = np.random.rand(self.batch_size, self.n)
         if self.wrap_by_variable:
             self.distrib = distribution.SoftmaxDistribution(
-                chainer.Variable(self.logits))
+                chainer.Variable(self.logits),
+                beta=self.beta,
+                min_prob=self.min_prob)
         else:
-            self.distrib = distribution.SoftmaxDistribution(self.logits)
+            self.distrib = distribution.SoftmaxDistribution(
+                self.logits,
+                beta=self.beta,
+                min_prob=self.min_prob)
 
     def test_sample(self):
         sample = self.distrib.sample()
@@ -47,7 +54,7 @@ class TestSoftmaxDistribution(unittest.TestCase):
             self.assertTrue(isinstance(batch_p, chainer.Variable))
             for b in range(self.batch_size):
                 p = batch_p.data[b]
-                self.assertGreaterEqual(p, 0)
+                self.assertGreaterEqual(p, self.min_prob)
                 self.assertLessEqual(p, 1)
             batch_ps.append(batch_p.data)
         np.testing.assert_almost_equal(sum(batch_ps), np.ones(self.batch_size))


### PR DESCRIPTION
- Add `min_prob` argument to `SoftmaxDistribution` and `SoftmaxPolicy`.
- Specify `min_prob` and `min_var` to stabilize agent training tests