### PR TITLE
train_agent_async without evaluation

### DIFF
--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -146,7 +146,8 @@ def train_agent_async(outdir, processes, make_env,
         make_env (callable): (process_idx, test) -> Environment.
         profile (bool): Profile if set True.
         steps (int): Number of global time steps for training.
-        eval_interval (int): Interval of evaluation.
+        eval_interval (int): Interval of evaluation. If set to None, the agent
+            will not be evaluated at all.
         eval_n_runs (int): Number of runs for each time of evaluation.
         max_episode_len (int): Maximum episode length.
         step_offset (int): Time step from which training starts.

--- a/chainerrl/experiments/train_agent_async.py
+++ b/chainerrl/experiments/train_agent_async.py
@@ -180,19 +180,25 @@ def train_agent_async(outdir, processes, make_env,
     shared_objects = extract_shared_objects_from_agent(agent)
     set_shared_objects(agent, shared_objects)
 
-    evaluator = AsyncEvaluator(
-        n_runs=eval_n_runs,
-        eval_interval=eval_interval, outdir=outdir,
-        max_episode_len=max_episode_len,
-        step_offset=step_offset,
-        explorer=eval_explorer,
-        logger=logger)
+    if eval_interval is None:
+        evaluator = None
+    else:
+        evaluator = AsyncEvaluator(
+            n_runs=eval_n_runs,
+            eval_interval=eval_interval, outdir=outdir,
+            max_episode_len=max_episode_len,
+            step_offset=step_offset,
+            explorer=eval_explorer,
+            logger=logger)
 
     def run_func(process_idx):
         random_seed.set_random_seed(process_idx)
 
         env = make_env(process_idx, test=False)
-        eval_env = make_env(process_idx, test=True)
+        if evaluator is None:
+            eval_env = env
+        else:
+            eval_env = make_env(process_idx, test=True)
         if make_agent is not None:
             local_agent = make_agent(process_idx)
             set_shared_objects(local_agent, shared_objects)


### PR DESCRIPTION
After this PR, If eval_interval is set to None, no evaluator nor eval_env will be created and the agent will not be evaluated.